### PR TITLE
Revert "Fixed Crone Job -> cronjob in README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Bot to automatically like your friends' Instagram posts, and notify you on your 
 
  How does it work?
 ================  
- This script runs Instagram API every 15mins (cronjob) and checks for any new Instagram post for a paticular `user_id`. If a new a post is found it likes the post and sends a notification to your configured Slack channel using Slack Webhooks.
+ This script runs Instagram API every 15mins (Crone Job) and checks for any new Instagram post for a paticular `user_id`. If a new a post is found it likes the post and sends a notification to your configured Slack channel using Slack Webhooks.
 
 Installation
 ===============
@@ -39,11 +39,11 @@ Deploy to Heroku
 
       http://<HEROKU_URL>.herokuapp.com/run
 
-Setting up Cron Job   
-===================
+Setting up Crone Job
+================  
 
  - create an account [cron-job.org](https://cron-job.org/en/)
- - create a cronjob
+ - create a cronejob
  - paste the url `http://<HEROKU_URL>.herokuapp.com/run` in address
  - schedule every `15 mins`
 


### PR DESCRIPTION
Why be like everyone else when you can stand out? Why be just a normal, cronjob-using developer when you can take a bold, daring strike into the unknown? Cronjobs are what dull, average, 9-to-5, cubicle dwelling developers use. Crone Jobs, on the other hand, are what a dashing hero might put to work, in between saving a litter of kittens and being elected president of the universe.

Pull request number 4 sucked the life from this project, turned it from a shining example of brilliant and innovative programming and vocabulary, to just another run-of-the-mill girlfriend-appeasing robot script. We must revert it in order to restore this project to its original glory.